### PR TITLE
Return this.items on dragApply

### DIFF
--- a/src/VueNestable.vue
+++ b/src/VueNestable.vue
@@ -462,7 +462,7 @@ export default {
     },
 
     dragApply () {
-      this.$emit('change', this.dragItem, { pathTo: this.pathTo })
+      this.$emit('change', this.dragItem, { items: this.items, pathTo: this.pathTo })
 
       this.pathTo = null
       this.itemsOld = null


### PR DESCRIPTION
This seems like a quick fix, does it have any implications in the code? 
It would be nice to have the whole tree returned when an item is dropped.