### PR TITLE
fix: module path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Ralph Huwiler <ralph@huwiler.rocks>",
   "homepage": "https://rhwilr.github.io/vue-nestable/",
   "license": "MIT",
-  "module": "dist/index.umd.js",
+  "module": "dist/index.umd.min.js",
   "main": "dist/index.umd.min.js",
   "unpkg": "dist/index.iife.min.js",
   "jsdelivr": "dist/index.iife.min.js",


### PR DESCRIPTION
Replace `dist/index.umd.js` (not found) with `dist/index.umd.min.js`.